### PR TITLE
Fix model matrix centering with only one predictor

### DIFF
--- a/R/glmmLasso_RE.R
+++ b/R/glmmLasso_RE.R
@@ -139,8 +139,8 @@ est.glmmLasso.RE<-function(fix,rnd,data,lambda,family,final.re,switch.NR,control
     if(!has.intercept & is.null(family$multivariate)) ## could be removed; already handled above
       stop("Need intercept term when using center = TRUE")
     
-    mu.x                 <- apply(X[,-intercept.which], 2, mean)
-    X[,-intercept.which] <- sweep(X[,-intercept.which], 2, mu.x)
+    mu.x                 <- apply(as.matrix(X[,-intercept.which]), 2, mean)
+    X[,-intercept.which] <- sweep(as.matrix(X[,-intercept.which]), 2, mu.x)
   }
   
   ## Standardize the design matrix -> blockwise orthonormalization

--- a/R/glmmLasso_noRE.R
+++ b/R/glmmLasso_noRE.R
@@ -140,8 +140,8 @@ est.glmmLasso.noRE<-function(fix,data,lambda,family,final.re,switch.NR,control)
     if(!has.intercept & is.null(family$multivariate)) ## could be removed; already handled above
       stop("Need intercept term when using center = TRUE")
     
-    mu.x                 <- apply(X[,-intercept.which], 2, mean)
-    X[,-intercept.which] <- sweep(X[,-intercept.which], 2, mu.x)
+    mu.x                 <- apply(as.matrix(X[,-intercept.which]), 2, mean)
+    X[,-intercept.which] <- sweep(as.matrix(X[,-intercept.which]), 2, mu.x)
   }
   
   ## Standardize the design matrix -> blockwise orthonormalization


### PR DESCRIPTION
If the model matrix contains only one predictor variable apart from the intercept, centering the predictor variables failed because R returns a vector instead of a matrix when matrix indexing results in a single column. I fixed this by encapsulating the indexing in an `as.matrix` function.